### PR TITLE
Updated to support Laravel 10.x and 11.x versions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "laravel/framework": "^6.20.12|^7.30.3|^8.4",
-        "guzzlehttp/guzzle": "^7.0",
-        "vdb/php-spider": "^v0.5.2",
+        "laravel/framework": "^6.20.12||^7.30.3||^8.4||^9.2",
+        "guzzlehttp/guzzle": "^7.2",
+        "vdb/php-spider": "^v0.6.3",
         "nesbot/carbon": "^2.41",
-        "spatie/robots-txt": "^1.0"
+        "spatie/robots-txt": "^1.0||^2.0"
     },
     "require-dev": {
         "symfony/thanks": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
-        "laravel/framework": "^6.20.12||^7.30.3||^8.4||^9.2",
+        "php": ">=8.1",
+        "laravel/framework": "^9.2||^10.0||^11.0",
         "guzzlehttp/guzzle": "^7.2",
-        "vdb/php-spider": "^v0.6.3",
+        "vdb/php-spider": "^v0.7.2",
         "nesbot/carbon": "^2.41",
         "spatie/robots-txt": "^1.0||^2.0"
     },

--- a/src/Commands/SitemapCommand.php
+++ b/src/Commands/SitemapCommand.php
@@ -71,7 +71,7 @@ class SitemapCommand extends Command
 
         // Add a URI discoverer. Without it, the spider does nothing.
         // In this case, we want <a> tags and the canonical link
-        $spider->getDiscovererSet()->set(new XPathExpressionDiscoverer("//div[@rel=\"canonical\"]//a"));
+        $spider->getDiscovererSet()->set(new XPathExpressionDiscoverer("//a|//link[@rel=\"canonical\"]"));
         $spider->getDiscovererSet()->addFilter(new AllowedHostsFilter([$url], true));
 
         // Set limits

--- a/src/Handlers/StatsHandler.php
+++ b/src/Handlers/StatsHandler.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace BringYourOwnIdeas\LaravelSitemap\Handlers;
+
+use VDB\Uri\UriInterface;
+use VDB\Spider\Event\SpiderEvents;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class StatsHandler
+ *
+ * @package BringYourOwnIdeas\LaravelSitemap\Handlers
+ */
+class StatsHandler implements EventSubscriberInterface
+{
+    /** @var string */
+    protected $spiderId;
+
+    protected $persisted = array();
+
+    protected $queued = array();
+
+    protected $filtered = array();
+
+    protected $failed = array();
+
+    public static function getSubscribedEvents(): array
+    {
+        return array(
+            SpiderEvents::SPIDER_CRAWL_FILTER_POSTFETCH => 'addToFiltered',
+            SpiderEvents::SPIDER_CRAWL_FILTER_PREFETCH => 'addToFiltered',
+            SpiderEvents::SPIDER_CRAWL_POST_ENQUEUE => 'addToQueued',
+            SpiderEvents::SPIDER_CRAWL_RESOURCE_PERSISTED => 'addToPersisted',
+            SpiderEvents::SPIDER_CRAWL_ERROR_REQUEST => 'addToFailed'
+        );
+    }
+
+    public function addToQueued(GenericEvent $event)
+    {
+        $this->queued[] = $event->getArgument('uri');
+    }
+
+    public function addToPersisted(GenericEvent $event)
+    {
+        $this->persisted[] = $event->getArgument('uri');
+    }
+
+    public function addToFiltered(GenericEvent $event)
+    {
+        $this->filtered[] = $event->getArgument('uri');
+    }
+
+    public function addToFailed(GenericEvent $event)
+    {
+        $this->failed[$event->getArgument('uri')->toString()] = $event->getArgument('message');
+    }
+
+    /**
+     * @return UriInterface[]
+     */
+    public function getQueued(): array
+    {
+        return $this->queued;
+    }
+
+    /**
+     * @return UriInterface[]
+     */
+    public function getPersisted(): array
+    {
+        return $this->persisted;
+    }
+
+    /**
+     * @return FilterableInterface[]
+     */
+    public function getFiltered(): array
+    {
+        return $this->filtered;
+    }
+
+    /**
+     * @return array of form array($uriString, $reason)
+     */
+    public function getFailed(): array
+    {
+        return $this->failed;
+    }
+
+    public function toString(): string
+    {
+        $spiderId = $this->getSpiderId();
+        $queued = $this->getQueued();
+        $filtered = $this->getFiltered();
+        $failed = $this->getFailed();
+
+        $string = '';
+
+        $string .= "\n\nSPIDER ID: " . $spiderId;
+        $string .= "\n  ENQUEUED:  " . count($queued);
+        $string .= "\n  SKIPPED:   " . count($filtered);
+        $string .= "\n  FAILED:    " . count($failed);
+
+        return $string;
+    }
+}

--- a/src/Handlers/StatsHandler.php
+++ b/src/Handlers/StatsHandler.php
@@ -15,43 +15,48 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class StatsHandler implements EventSubscriberInterface
 {
     /** @var string */
-    protected $spiderId;
+    protected string $spiderId;
 
-    protected $persisted = array();
+    protected array $persisted = [];
 
-    protected $queued = array();
+    protected array $queued = [];
 
-    protected $filtered = array();
+    protected array $filtered = [];
 
-    protected $failed = array();
+    protected array $failed = [];
 
     public static function getSubscribedEvents(): array
     {
-        return array(
+        return [
             SpiderEvents::SPIDER_CRAWL_FILTER_POSTFETCH => 'addToFiltered',
             SpiderEvents::SPIDER_CRAWL_FILTER_PREFETCH => 'addToFiltered',
             SpiderEvents::SPIDER_CRAWL_POST_ENQUEUE => 'addToQueued',
             SpiderEvents::SPIDER_CRAWL_RESOURCE_PERSISTED => 'addToPersisted',
             SpiderEvents::SPIDER_CRAWL_ERROR_REQUEST => 'addToFailed'
-        );
+        ];
     }
 
-    public function addToQueued(GenericEvent $event)
+    private function getSpiderId(): string
+    {
+        return $this->spiderId;
+    }
+
+    public function addToQueued(GenericEvent $event): void
     {
         $this->queued[] = $event->getArgument('uri');
     }
 
-    public function addToPersisted(GenericEvent $event)
+    public function addToPersisted(GenericEvent $event): void
     {
         $this->persisted[] = $event->getArgument('uri');
     }
 
-    public function addToFiltered(GenericEvent $event)
+    public function addToFiltered(GenericEvent $event): void
     {
         $this->filtered[] = $event->getArgument('uri');
     }
 
-    public function addToFailed(GenericEvent $event)
+    public function addToFailed(GenericEvent $event): void
     {
         $this->failed[$event->getArgument('uri')->toString()] = $event->getArgument('message');
     }


### PR DESCRIPTION
hi @spekulatius 

two years past and I need this package again for one project upgrade
this time I need it with Laravel 11.x and PHP 8.2
but I think requiring PHP 8.1 or greater is completely enough 

it would be great if you could find some time to take a look at changes

most of the changes are for composer.json
I also added types and return declarations in classes

as about `src/Commands/SitemapCommand.php` `crawlWebsite()` change on :75 string
I had this error for `XPathExpressionDiscoverer` before:

> Please end your selector with '/a': selectors should look for `a` elements so that the Discoverer can extract their `href` attribute for further crawling.

and the change fixed it


it looks like there is a conflict between my fork and your origin package
I will check it out later

hope to hear from u soon 😌